### PR TITLE
Windows and macOS compile fixes

### DIFF
--- a/core/config/sl_chacha20poly1305ietf_config.h
+++ b/core/config/sl_chacha20poly1305ietf_config.h
@@ -62,6 +62,8 @@
 #   define HAVE_SYS_STAT_H 1
 #   define HAVE_SYS_MMAN_H 1
 #   define HAVE_DLFCN_H 1
+#  elif defined __APPLE__
+#   define HAVE_SYS_MMAN_H 1
 #  endif
 
 #  define HAVE_STDLIB_H 1
@@ -95,7 +97,9 @@
 #  if defined __i386__ || defined __x86_64__
 #   define HAVE_CPUID 1
 #  endif
-#  define HAVE_WEAK_SYMBOLS 1
+#  if !defined _MSC_VER
+#   define HAVE_WEAK_SYMBOLS 1
+#  endif
 #  define HAVE_ATOMIC_OPS 1
 #  define HAVE_MMAP 1
 #  define HAVE_MLOCK 1

--- a/core/include/psPrnf.h
+++ b/core/include/psPrnf.h
@@ -147,9 +147,15 @@ const char *psPrnfBase64(psPrnf_t *ctx, const unsigned char *octets, psSizeL_t l
                          int(*formatter)(const unsigned char *, size_t, const char *, char **));
 const char *psPrnfIpv4(psPrnf_t *ctx, uint32_t ipv4_addr);
 
-int psPrnf_(psPrnf_t *ctx, const char *fmt, ...) __attribute__((__format__(printf, 2, 3)));
-int psSnprnf_(char *str, psSizeL_t size, psPrnf_t *ctx, const char *fmt, ...) __attribute__((__format__(printf, 4, 5)));
-char *psAsprnf_(psPool_t *pool, psPrnf_t *ctx, const char *fmt, ...) __attribute__((__format__(printf, 3, 4)));
+#if defined(WIN32)
+int psPrnf_(psPrnf_t *ctx, const char *fmt, ...);
+int psSnprnf_(char *str, psSizeL_t size, psPrnf_t *ctx, const char *fmt, ...);
+char *psAsprnf_(psPool_t *pool, psPrnf_t *ctx, const char *fmt, ...);
+#else
+int psPrnf_(psPrnf_t* ctx, const char* fmt, ...) __attribute__((__format__(printf, 2, 3)));
+int psSnprnf_(char* str, psSizeL_t size, psPrnf_t* ctx, const char* fmt, ...) __attribute__((__format__(printf, 4, 5)));
+char* psAsprnf_(psPool_t* pool, psPrnf_t* ctx, const char* fmt, ...) __attribute__((__format__(printf, 3, 4)));
+#endif
 
 /** Extended formatted printing.
 

--- a/core/include/public_defs.h
+++ b/core/include/public_defs.h
@@ -49,6 +49,10 @@
 
 #if defined(WIN32)
 
+#if defined(_MSC_VER) && _MSC_VER >= 1900
+#include <stdint.h>
+#include <stdbool.h>
+#else
 typedef signed char int8_t;
 typedef signed short int16_t;
 typedef signed int int32_t;
@@ -87,6 +91,7 @@ typedef uint8_t bool;
 # define UINT32_MAX (4294967295)
 
 # define restrict
+#endif
 
 #elif (defined(__KERNEL__))
 

--- a/core/include/sfzcl/sfzclincludes.h
+++ b/core/include/sfzcl/sfzclincludes.h
@@ -48,7 +48,6 @@
 /* Windows API */
 # ifndef SFZCLDIST_FREESTANDING
 #  include "osdep_windows.h"
-#  include "osdep_winbase.h"
 #  include "osdep_fcntl.h"
 # endif                         /* !SFZCLDIST_FREESTANDING */
 

--- a/core/osdep/WIN32/osdep.c
+++ b/core/osdep/WIN32/osdep.c
@@ -33,7 +33,7 @@
 /******************************************************************************/
 
 #include "../coreApi.h"
-#include "../osdep.h"
+#include "../include/osdep.h"
 
 #ifdef WIN32
 # include "osdep_wincrypt.h"

--- a/core/osdep/include/osdep-types.h
+++ b/core/osdep/include/osdep-types.h
@@ -309,6 +309,9 @@ typedef struct
 #  endif
 # endif
 
+#if defined(WIN32)
+typedef LARGE_INTEGER psTime_t;
+#else
 /* Data type that allocated sufficient space for psTime_t regardless
    of implementation with internal implementation structure where requested. */
 typedef union {
@@ -317,6 +320,7 @@ typedef union {
        psTimeConcrete_t psTimeInternal;
 # endif
 } psTime_t;
+#endif
 
 # ifdef USE_HIGHRES_TIME
 extern int64_t psDiffUsecs(psTime_t then, psTime_t now);

--- a/core/src/utils.c
+++ b/core/src/utils.c
@@ -665,8 +665,6 @@ SLSodium_free(void *ptr)
 }
 # endif /* HAVE_ALIGNED_MALLOC */
 
-#endif /* NO_SODIUM_MEMORY_MANAGEMENT */
-
 # ifndef HAVE_PAGE_PROTECTION
 static int
 SLSodium_mprotect(void *ptr, int (*cb)(void *ptr, size_t size))
@@ -709,5 +707,9 @@ SLSodium_mprotect_readwrite(void *ptr)
 {
     return SLSodium_mprotect(ptr, SLMprotect_readwrite);
 }
+
+#endif /* NO_SODIUM_MEMORY_MANAGEMENT */
+
+
 
 #endif /* USE_SL_CHACHA20_POLY1305_IETF || USE_SL_SODIUM */

--- a/crypto/aead/chacha20poly1305ietf/ps_chacha20poly1305ietf_config.h
+++ b/crypto/aead/chacha20poly1305ietf/ps_chacha20poly1305ietf_config.h
@@ -60,6 +60,8 @@
 #   define HAVE_SYS_STAT_H 1
 #   define HAVE_SYS_MMAN_H 1
 #   define HAVE_DLFCN_H 1
+#  elif defined __APPLE__
+#   define HAVE_SYS_MMAN_H 1
 #  endif
 
 #  define HAVE_STDLIB_H 1
@@ -96,7 +98,9 @@
 #  define HAVE_WEAK_SYMBOLS 1
 #  define HAVE_ATOMIC_OPS 1
 #  define HAVE_MMAP 1
-#  define HAVE_MLOCK 1
+#  if !defined(WIN32)
+#    define HAVE_MLOCK 1
+#  endif
 #  define HAVE_MADVISE 1
 #  define HAVE_NANOSLEEP 1
 #  define HAVE_POSIX_MEMALIGN 1

--- a/crypto/aead/chacha20poly1305ietf/utils.c
+++ b/crypto/aead/chacha20poly1305ietf/utils.c
@@ -663,8 +663,6 @@ psSodium_free(void *ptr)
 }
 # endif /* HAVE_ALIGNED_MALLOC */
 
-#endif /* NO_SODIUM_MEMORY_MANAGEMENT */
-
 # ifndef HAVE_PAGE_PROTECTION
 static int
 psSodium_mprotect(void *ptr, int (*cb)(void *ptr, size_t size))
@@ -707,5 +705,7 @@ psSodium_mprotect_readwrite(void *ptr)
 {
     return psSodium_mprotect(ptr, psMprotect_readwrite);
 }
+
+#endif /* NO_SODIUM_MEMORY_MANAGEMENT */
 
 #endif /* USE_MATRIX_CHACHA20_POLY1305_IETF */

--- a/matrixssl/matrixsslApiCipher.h
+++ b/matrixssl/matrixsslApiCipher.h
@@ -36,6 +36,9 @@
 #ifndef _h_MATRIXSSL_API_CIPHER
 # define _h_MATRIXSSL_API_CIPHER
 
+#if defined __APPLE__
+#include <Security/CipherSuite.h>
+#else
 /* Cipher suite specification IDs, in numerical order. */
 # define SSL_NULL_WITH_NULL_NULL                 0x0000
 # define SSL_RSA_WITH_NULL_MD5                   0x0001
@@ -67,6 +70,7 @@
 # define TLS_RSA_WITH_AES_128_GCM_SHA256         0x009C /* 156 */
 # define TLS_RSA_WITH_AES_256_GCM_SHA384         0x009D /* 157 */
 # define TLS_DHE_RSA_WITH_AES_256_GCM_SHA384     0x009F /* 159 */
+#endif // __APPLE__
 
 # define TLS_EMPTY_RENEGOTIATION_INFO_SCSV       0x00FF /**< @see RFC 5746 */
 # define TLS_FALLBACK_SCSV                       0x5600 /**< @see RFC 7507 */

--- a/matrixssl/matrixsslSocket.c
+++ b/matrixssl/matrixsslSocket.c
@@ -37,7 +37,9 @@
 #include "osdep_stdio.h"
 #include "osdep_unistd.h"
 #include "osdep_sys_types.h"
+#if defined(USE_PS_NETWORKING)
 #include "osdep_sys_socket.h"
+#endif
 #include "osdep_string.h"
 
 #define USE_MATRIX_NET_DEBUG


### PR DESCRIPTION
This fixes a number of compile problems on Window and macOS.  However, it's not a complete solution.  I maintain my own CMake project files and do not use the Makefiles that ship with the repo, and the Makefiles still do have some problems on macOS.

I might suggest moving toward cmake as it can generate various files for various build systems (e.g. Makefiles, vcproj, XCode projects, etc).  Contact me if you are interested in that possibility, as it would be a chore to support the all configurations/options purportedly offered by the current Makefiles.
